### PR TITLE
Modified behavior to treat "floating" events found in a calendar with…

### DIFF
--- a/test/calendars/single-event-no-tz.in.ics
+++ b/test/calendars/single-event-no-tz.in.ics
@@ -1,0 +1,15 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:manually_generated
+X-WR-TIMEZONE:Europe/Brussels
+X-WR-CALNAME:MyCalendar
+X-WR-CALDESC:Description of calendar
+BEGIN:VEVENT
+UID:match_1025179
+DTSTAMP:20210911T014015Z
+DESCRIPTION:When X-WR-TIMEZONE is ignored, this is a floating event, when it is interpreted, the event is assumed to be in the Europe/Brussels timezone
+DTSTART:20210916T210000
+DTEND:20210916T224500
+SUMMARY:X-WR-TIMEZONE no timezone
+END:VEVENT
+END:VCALENDAR

--- a/test/calendars/single-event-no-tz.out.ics
+++ b/test/calendars/single-event-no-tz.out.ics
@@ -1,0 +1,15 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:manually_generated
+X-WR-TIMEZONE:Europe/Brussels
+X-WR-CALNAME:MyCalendar
+X-WR-CALDESC:Description of calendar
+BEGIN:VEVENT
+UID:match_1025179
+DTSTAMP:20210911T014015Z
+DESCRIPTION:When X-WR-TIMEZONE is ignored, this is a floating event, when it is interpreted, the event is assumed to be in the Europe/Brussels timezone
+DTSTART;TZID=Europe/Brussels:20210916T210000
+DTEND;TZID=Europe/Brussels:20210916T224500
+SUMMARY:X-WR-TIMEZONE no timezone
+END:VEVENT
+END:VCALENDAR

--- a/test/test_convert_examples.py
+++ b/test/test_convert_examples.py
@@ -76,6 +76,19 @@ def test_conversion_changes_the_time_zone(to_standard, calendars, calendar_name,
     assert_has_line(output_bytes, content, message)
 
 
+@pytest.mark.parametrize("calendar_name,content,message", [
+    ("single-event-no-tz.in.ics", ("DTSTART", "TZID=Europe/Brussels", ":20210916T210000"), "DTSTART should be updated."),
+    ("single-event-no-tz.in.ics", ("DTEND", "TZID=Europe/Brussels", ":20210916T224500"), "DTEND should be updated."),
+    ("single-event-no-tz.out.ics", ("DTSTART", "TZID=Europe/Brussels", ":20210916T210000"), "DTSTART stays the same in already converted calendar."),
+])
+def test_conversion_adds_the_time_zone(to_standard, calendars, calendar_name, content, message):
+    calendar = calendars[calendar_name]
+    new_calendar = to_standard(calendar.as_icalendar())
+    output_bytes = new_calendar.to_ical()
+    print(output_bytes)
+    assert_has_line(output_bytes, content, message)
+
+
 @pytest.mark.parametrize("tz,line,message,calendar_name", [
     ("Europe/Paris", ("DTSTART", "TZID=Europe/Paris" ,"20211223T030000"), "(1) Use string as timezone", "single-events-DTSTART-DTEND.in.ics"),
     (pytz.timezone("Europe/Berlin"), ("DTSTART", "TZID=Europe/Berlin", "20211223T030000"), "(2) Use pytz.timezone as timezone", "single-events-DTSTART-DTEND.in.ics"),

--- a/x_wr_timezone.py
+++ b/x_wr_timezone.py
@@ -111,7 +111,12 @@ class CalendarWalker:
 
     def is_UTC(self, dt):
         """Return whether the time zone is a UTC time zone."""
+        if dt.tzname() is None:
+            return False
         return dt.tzname().upper() == "UTC"
+
+    def is_Floating(self, dt):
+        return dt.tzname() is None
 
 
 class UTCChangingWalker(CalendarWalker):
@@ -125,6 +130,8 @@ class UTCChangingWalker(CalendarWalker):
         """Walk along a datetime.datetime object."""
         if self.is_UTC(dt):
             return dt.astimezone(self.new_timezone)
+        elif self.is_Floating(dt):
+            return dt.replace(tzinfo=self.new_timezone)
         return dt
 
 


### PR DESCRIPTION
… X-WR-TIMEZONE as if they are in the time zone specified

The code was crashing because of the check in is_UTC not checking if a
timezone existed or not.  If there was no timezone, then the code
crashed.  This matches the case of a "floating" event, which is normally
interpreted as being in the current time zone.

This change treats these "floating" events as if they are in the
timezone specified by X-WR-TIMEZONE, and not as "floating" events.
Based on https://github.com/u01jmg3/ics-parser/issues/245 and
https://blog.jonudell.net/2011/10/17/x-wr-timezone-considered-harmful/,
and a calendar a user sent me, I think this is what was intended by the
calendars' authors.  It's hard to say for sure, though, since I've been
unable to find any definitive documentation, only educated guesses.

Note: New tests were added, and the existing tests still pass with
these changes.