### PR TITLE
 Use proper SPDX license ID

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ METADATA = dict(
     author=__author__,
     author_email='niccokunzmann@rambler.ru',
     description='A Python module and program to convert calendars using X-WR-TIMEZONE to standard ones.',
-    license='LGPLv3+',
+    license='LGPL-3.0-or-later',
     url='https://github.com/niccokunzmann/x-wr-timezone',
     keywords='icalendar',
     entry_points="[console_scripts]\nx-wr-timezone = x_wr_timezone:main",


### PR DESCRIPTION
Hey,

my dependencyscanner is unfortunately not able to extract the right license of your project. Perhaps you could be so kind and use the SPDX identifier?
https://spdx.org/licenses/
That might not only be an issue for me but others as well.

Thank you for your work
Max