### PR TITLE
Ignore invalid calendar X-WR-TIMEZONE

### DIFF
--- a/test/test_convert_examples.py
+++ b/test/test_convert_examples.py
@@ -1,5 +1,6 @@
 """This test converts example calendars"""
 import datetime
+import icalendar
 import pytest
 import x_wr_timezone
 import zoneinfo
@@ -113,3 +114,29 @@ def test_timezone_parameter(calendars, tz, line, message, calendar_name):
     new_calendar = x_wr_timezone.to_standard(calendar.as_icalendar(), timezone=tz)
     output_bytes = new_calendar.to_ical()
     assert_has_line(output_bytes, line, message)
+
+
+def test_invalid_x_wr_timezone_does_not_fail():
+    calendar = icalendar.Calendar.from_ical(b"""BEGIN:VCALENDAR
+VERSION:2.0
+X-WR-TIMEZONE:d6708488efb330c0
+BEGIN:VEVENT
+UID:invalid-x-wr-timezone
+DTSTART:20260101T120000Z
+DTEND:20260101T130000Z
+SUMMARY:Invalid X-WR-TIMEZONE
+END:VEVENT
+END:VCALENDAR
+""")
+
+    new_calendar = x_wr_timezone.to_standard(calendar)
+
+    assert new_calendar is calendar
+    assert new_calendar.to_ical() == calendar.to_ical()
+
+
+def test_invalid_timezone_parameter_still_fails(calendars):
+    calendar = calendars["single-events-DTSTART-DTEND.in.ics"].as_icalendar()
+
+    with pytest.raises(zoneinfo.ZoneInfoNotFoundError):
+        x_wr_timezone.to_standard(calendar, timezone="d6708488efb330c0")

--- a/x_wr_timezone.py
+++ b/x_wr_timezone.py
@@ -186,10 +186,17 @@ def to_standard(
         
         add_timezone_component: whether to add a VTIMEZONE component to the result.
     """
-    if timezone is None:
+    timezone_from_calendar = timezone is None
+    if timezone_from_calendar:
         timezone = calendar.get(X_WR_TIMEZONE, None)
     if timezone is not None and not isinstance(timezone, datetime.tzinfo):
-        timezone = zoneinfo.ZoneInfo(str(timezone))
+        try:
+            timezone = zoneinfo.ZoneInfo(str(timezone))
+        except zoneinfo.ZoneInfoNotFoundError:
+            if timezone_from_calendar:
+                timezone = None
+            else:
+                raise
     result : icalendar.Calendar = calendar
     del calendar
     if timezone is not None:


### PR DESCRIPTION
Fixes #31

## Summary
- Treat invalid `X-WR-TIMEZONE` values from the input calendar as absent instead of raising during conversion.
- Preserve strict behavior for an explicitly passed invalid `timezone=` argument.
- Add regression coverage for the invalid calendar field and explicit-argument cases.

## Duplicate check
- Checked existing PRs for issue #31, `Invalid X-WR-TIMEZONE`, and `d6708488efb330c0`; no matching PRs found.
- Checked issue #31 comments before submitting; no visible competing fix/discussion was present.

## Tests
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest test/test_convert_examples.py test/test_copy.py test/test_command_line.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest -q`
- `sh test/test_code_quality.sh`
- `git diff --check`

Note: CONTRIBUTING.md asks for changelog entries except trivial changes, but I could not find a changelog/news file in this repository to update.