### PR TITLE
Restore CalendarWalker is_UTC compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,10 @@ how to go about it.
 Changelog
 ---------
 
+- v3.0.1
+
+  - Reintroduce ``CalendarWalker.is_UTC()`` as a compatibility hook backed by ``icalendar.is_utc()``.
+
 - v3.0.0
 
   - Use ``icalendar.is_utc()`` instead of ``is_UTC()`` to identify UTC, catching aliases like ``Etc/GMT``.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ PACKAGE_NAME = "x_wr_timezone"
 HERE = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, HERE)  # for package import
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 __author__ = 'Nicco Kunzmann'
 
 

--- a/test/test_convert_examples.py
+++ b/test/test_convert_examples.py
@@ -113,3 +113,12 @@ def test_timezone_parameter(calendars, tz, line, message, calendar_name):
     new_calendar = x_wr_timezone.to_standard(calendar.as_icalendar(), timezone=tz)
     output_bytes = new_calendar.to_ical()
     assert_has_line(output_bytes, line, message)
+
+
+def test_calendar_walker_is_utc_compatibility_hook():
+    walker = x_wr_timezone.CalendarWalker()
+    utc_dt = datetime.datetime(2026, 1, 1, tzinfo=zoneinfo.ZoneInfo("Etc/GMT"))
+    floating_dt = datetime.datetime(2026, 1, 1)
+
+    assert walker.is_UTC(utc_dt)
+    assert not walker.is_UTC(floating_dt)

--- a/x_wr_timezone.py
+++ b/x_wr_timezone.py
@@ -126,6 +126,11 @@ class CalendarWalker:
         """Walk along a datetime.datetime object."""
         return dt
 
+    @staticmethod
+    def is_UTC(dt):
+        """Return whether the time zone is a UTC time zone."""
+        return is_utc(dt)
+
     def is_Floating(self, dt):
         return dt.tzname() is None
 
@@ -157,7 +162,7 @@ class UTCChangingWalker(CalendarWalker):
 
     def walk_value_datetime(self, dt):
         """Walk along a datetime.datetime object."""
-        if is_utc(dt):
+        if self.is_UTC(dt):
             return dt.astimezone(self.new_timezone)
         elif self.is_Floating(dt):
             if is_pytz(self.new_timezone):


### PR DESCRIPTION
Fixes #34

## Summary
- Reintroduce `CalendarWalker.is_UTC()` as a compatibility hook backed by the current `icalendar.is_utc()` behavior.
- Route `UTCChangingWalker` through `self.is_UTC(dt)` again, preserving the old subclass/override hook while keeping UTC alias support such as `Etc/GMT`.
- Bump the package patch version to `3.0.1` and add a changelog note.
- Add regression coverage for the restored compatibility hook.

## Duplicate check
- Checked issue #34 comments; no comments or competing notes were present.
- `gh pr list --repo pycalendar/x-wr-timezone --state all --search "34 Next Release is_UTC version bump"` returned no PRs.
- `gh pr list --repo pycalendar/x-wr-timezone --state all --search "is_UTC CalendarWalker is_utc"` returned no PRs.

## Tests
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest test/test_convert_examples.py test/test_copy.py test/test_command_line.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest -q`
- `sh test/test_code_quality.sh`
- `PATH="$PWD/.venv/bin:$PATH" x-wr-timezone --version`
- `git diff --check`