### PR TITLE
Make click optional for library installs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,12 @@ Install using ``pip``:
 
     python3 -m pip install x-wr-timezone
 
+Install the command line interface using the ``cli`` extra:
+
+.. code:: shell
+
+    python3 -m pip install x-wr-timezone[cli]
+
 Install with ``apt``:
 
 .. code:: shell
@@ -74,6 +80,7 @@ Command Line Usage
 ------------------
 
 You can standardize the calendars using your command line interface.
+Install ``x-wr-timezone[cli]`` to use the command.
 The examples assume that ``in.ics`` is a calendar which may use
 ``X-WR-TIMEZONE``, whereas ``out.ics`` does not require ``X-WR-TIMEZONE``
 for proper display.
@@ -236,6 +243,12 @@ how to go about it.
 
 Changelog
 ---------
+
+- v4.0.0
+
+  - Make ``click`` optional for library users.
+  - Add a ``cli`` extra for installing the command line interface.
+  - Document ``pip install x-wr-timezone[cli]`` for command line usage.
 
 - v3.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 icalendar>=6.1.0
 tzdata
-click

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ PACKAGE_NAME = "x_wr_timezone"
 HERE = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, HERE)  # for package import
 
-__version__ = "3.0.0"
+__version__ = "4.0.0"
 __author__ = 'Nicco Kunzmann'
 
 
@@ -118,6 +118,9 @@ required_test_packages = read_requirements_file("test-requirements.txt")
 
 SETUPTOOLS_METADATA = dict(
     install_requires=required_packages,
+    extras_require={
+        "cli": ["click"],
+    },
     tests_require=required_test_packages,
     include_package_data=False,
     classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/test/test_click_optional.py
+++ b/test/test_click_optional.py
@@ -1,0 +1,52 @@
+"""Test that click is optional for library users."""
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def restore_imported_modules():
+    """Keep the simulated missing dependency scoped to each test."""
+    original_module = sys.modules.get("x_wr_timezone")
+    original_click = sys.modules.get("click")
+    yield
+    sys.modules.pop("x_wr_timezone", None)
+    sys.modules.pop("click", None)
+    if original_module is not None:
+        sys.modules["x_wr_timezone"] = original_module
+    if original_click is not None:
+        sys.modules["click"] = original_click
+
+
+def import_x_wr_timezone_without_click(monkeypatch):
+    """Import x_wr_timezone with click hidden from the import system."""
+    real_import = builtins.__import__
+
+    def import_without_click(name, *args, **kwargs):
+        if name == "click":
+            raise ImportError("No module named 'click'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_click)
+    sys.modules.pop("x_wr_timezone", None)
+    sys.modules.pop("click", None)
+    return importlib.import_module("x_wr_timezone")
+
+
+def test_import_without_click(monkeypatch):
+    """Importing the library should not require the cli extra."""
+    module = import_x_wr_timezone_without_click(monkeypatch)
+
+    assert hasattr(module, "to_standard")
+
+
+def test_cli_reports_missing_click(monkeypatch):
+    """The command should explain how to install its optional dependency."""
+    module = import_x_wr_timezone_without_click(monkeypatch)
+
+    with pytest.raises(SystemExit) as exit_info:
+        module.main()
+
+    assert "x-wr-timezone[cli]" in str(exit_info.value)

--- a/x_wr_timezone.py
+++ b/x_wr_timezone.py
@@ -19,9 +19,17 @@ from icalendar.prop import vDDDTypes, vDDDLists
 import datetime
 import icalendar
 from typing import Optional
-import click
 
 X_WR_TIMEZONE = "X-WR-TIMEZONE"
+CLICK_EXTRA_MESSAGE = (
+    "The x-wr-timezone command line interface requires click. "
+    "Install it with `pip install x-wr-timezone[cli]`."
+)
+
+try:
+    import click
+except ImportError:
+    click = None
 
 
 def _is_utc_fallback(dt):
@@ -202,42 +210,54 @@ def to_standard(
             result.subcomponents.insert(0, get_timezone_component(timezone))
     return result
 
-@click.command()
-@click.argument('in_file', type=click.File('rb'), default="-")
-@click.argument('out_file', type=click.File('wb'), default="-")
-@click.version_option()
-@click.help_option()
-@click.option('--add-timezone/--no-timezone', default=True, help="Add a VTIMEZONE component to the result.")
-def main(in_file:BytesIO, out_file:BytesIO, add_timezone: bool):
-    """x-wr-timezone converts ICS files with X-WR-TIMEZONE to use RFC 5545 instead.
-
-    Convert input:
-
-        cat in.ics | x-wr-timezone > out.ics
-        wget -O- https://example.org/in.ics | x-wr-timezone > out.ics
-        curl https://example.org/in.ics | x-wr-timezone > out.ics
-
-    Convert files:
-
-        x-wr-timezone in.ics out.ics
-
-    By default, x-wr-timezone will add a VTIMEZONE component to the result.
-    Use --no-vtimezone to remove it. (Added in v2.0.0)
-
-    Get help:
-
-        x-wr-timezone --help
-
-    For bug reports, code and questions, visit the project page:
-
-        https://github.com/pycalendar/x-wr-timezone
-
-    License: LPGLv3+
-    """
+def _convert(in_file:BytesIO, out_file:BytesIO, add_timezone: bool):
     calendar = icalendar.Calendar.from_ical(in_file.read())
     new_cal = to_standard(calendar, add_timezone_component=add_timezone)
     out_file.write(new_cal.to_ical())
     return 0
+
+
+CLI_DOC = """x-wr-timezone converts ICS files with X-WR-TIMEZONE to use RFC 5545 instead.
+
+Convert input:
+
+    cat in.ics | x-wr-timezone > out.ics
+    wget -O- https://example.org/in.ics | x-wr-timezone > out.ics
+    curl https://example.org/in.ics | x-wr-timezone > out.ics
+
+Convert files:
+
+    x-wr-timezone in.ics out.ics
+
+By default, x-wr-timezone will add a VTIMEZONE component to the result.
+Use --no-vtimezone to remove it. (Added in v2.0.0)
+
+Get help:
+
+    x-wr-timezone --help
+
+For bug reports, code and questions, visit the project page:
+
+    https://github.com/pycalendar/x-wr-timezone
+
+License: LPGLv3+
+"""
+
+
+if click is None:
+    def main(*args, **kwargs):
+        raise SystemExit(CLICK_EXTRA_MESSAGE)
+else:
+    @click.command(help=CLI_DOC)
+    @click.argument('in_file', type=click.File('rb'), default="-")
+    @click.argument('out_file', type=click.File('wb'), default="-")
+    @click.version_option()
+    @click.help_option()
+    @click.option('--add-timezone/--no-timezone', default=True, help="Add a VTIMEZONE component to the result.")
+    def main(in_file:BytesIO, out_file:BytesIO, add_timezone: bool):
+        return _convert(in_file, out_file, add_timezone)
+
+main.__doc__ = CLI_DOC
 
 
 __all__ = [


### PR DESCRIPTION
Fixes #26.

This follows the maintainer checklist from the issue:
- removes `click` from the base runtime requirements
- adds a `cli` extra via `extras_require`
- bumps the package version to the next major version, `4.0.0`
- documents `pip install x-wr-timezone[cli]` for command line usage

Implementation details:
- importing `x_wr_timezone` no longer requires `click`
- when `click` is installed, `x_wr_timezone.main` remains a Click command object, preserving the existing CLI tests and entry point behavior
- when `click` is missing, the CLI entry point exits with a clear install hint

Verification:
```powershell
$env:Path = "$PWD\.venv\Scripts;$env:Path"
.\.venv\Scripts\python -m pytest
```
Result: `162 passed, 188 skipped, 2 warnings`.

Additional checks:
```powershell
& 'C:\Program Files\Git\bin\bash.exe' test/test_code_quality.sh
.\.venv\Scripts\python -m pip check
.\.venv-no-click\Scripts\python -m pip check
```

No-CLI install smoke:
```powershell
.\.venv-no-click\Scripts\python -m pip install -e .
$env:Path = "$PWD\.venv-no-click\Scripts;$env:Path"
.\.venv-no-click\Scripts\python -c "import importlib.util, x_wr_timezone; print('click', importlib.util.find_spec('click')); print('has_to_standard', hasattr(x_wr_timezone, 'to_standard'));"
x-wr-timezone --help
```
Observed `click None`, `has_to_standard True`, and the CLI prints the `pip install x-wr-timezone[cli]` hint when `click` is not installed.