### PR TITLE
Fix migrated contribution links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guide
 
-To get started with development, [read the documentation](README.md).
+To get started with development, [read the documentation](README.rst).
 
 ## Maintainers
 
@@ -8,7 +8,7 @@ Maintainers are:
 
 - [Nicco Kunzmann](https://github.com/niccokunzmann)
 - [Steve Piercy](https://github.com/stevepiercy)
-- [Sashank Bhamidi](github.com/SashankBhamidi)
+- [Sashank Bhamidi](https://github.com/SashankBhamidi)
 
 They can:
 
@@ -41,4 +41,3 @@ Contributors
 ## Stale pull requests
 
 If an open pull request has had no activity for at least seven days, either through a comment or commit by the contributor, then a maintainer or code owner should ask the contributor whether they need help to complete the work. After another seven days, the maintainer or code owner may resolve the open pull request using their best judgment.
-


### PR DESCRIPTION
## Summary
- point the contribution guide at the repo's actual `README.rst` file instead of the old/missing `README.md` path
- fix the Sashank maintainer link so it is a complete GitHub URL

## Duplicate / competition check
- `gh issue view 33 --repo pycalendar/x-wr-timezone --comments` showed issue #33 open, unassigned, and with no comments/work claim
- `gh pr list --repo pycalendar/x-wr-timezone --state all --search "33 Check migration"` returned `[]`
- broader migration searches found merged release/migration PRs and my open #38 compatibility PR, but no contribution-link cleanup for #33

## Verification
- `git diff --check`
- `python3 setup.py --help-commands` confirmed the release helper command is still registered, though setuptools prints unrelated deprecation warnings
- `sh test/test_code_quality.sh`

This addresses a small concrete migration-docs cleanup from #33; it does not require any release or account action.