### PR TITLE
Add PyPI funding project links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,13 @@ required_test_packages = read_requirements_file("test-requirements.txt")
 SETUPTOOLS_METADATA = dict(
     install_requires=required_packages,
     tests_require=required_test_packages,
+    project_urls={
+        "GitHub Sponsors": "https://github.com/sponsors/niccokunzmann",
+        "Open Collective": "https://opencollective.com/open-web-calendar/",
+        "Polar": "https://polar.sh/niccokunzmann",
+        "thanks.dev": "https://thanks.dev",
+        "Tidelift": "https://tidelift.com/lifter/search/pypi/x-wr-timezone",
+    },
     include_package_data=False,
     classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Intended Audience :: Developers',

--- a/test/test_issue_24_funding_links.py
+++ b/test/test_issue_24_funding_links.py
@@ -1,0 +1,17 @@
+"""Check PyPI project links."""
+
+import setup
+
+
+def test_funding_links_are_exposed_to_pypi():
+    """Funding links should be included in package metadata."""
+    project_urls = setup.SETUPTOOLS_METADATA["project_urls"]
+
+    assert project_urls["GitHub Sponsors"] == "https://github.com/sponsors/niccokunzmann"
+    assert project_urls["Open Collective"] == "https://opencollective.com/open-web-calendar/"
+    assert project_urls["Polar"] == "https://polar.sh/niccokunzmann"
+    assert project_urls["thanks.dev"] == "https://thanks.dev"
+    assert (
+        project_urls["Tidelift"]
+        == "https://tidelift.com/lifter/search/pypi/x-wr-timezone"
+    )


### PR DESCRIPTION
## Summary
- add funding project URLs to the package metadata used for PyPI
- cover the metadata links with a focused regression test

Fixes #24

Note: this repository still uses setup.py instead of pyproject.toml, so this adds the links to the current packaging metadata source.

## Verification
- .venv/bin/python -m pytest test/test_issue_24_funding_links.py
- .venv/bin/python setup.py --version && .venv/bin/python setup.py --name && .venv/bin/python setup.py --url
- .venv/bin/python setup.py bdist_wheel && unzip -p dist/*.whl '*/METADATA' | rg -n 'Project-URL|GitHub Sponsors|Open Collective|Polar|thanks.dev|Tidelift'
- git diff --check